### PR TITLE
fix: Profiles for check-config services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
         condition: service_completed_successfully
       prysm-keygen:
         condition: service_completed_successfully
-    profiles: ["init", "node", "validator", "manual"]
+    profiles: ["validator", "manual"]
     secrets:
       - account_password
       - deposit_private_key
@@ -140,7 +140,7 @@ services:
         condition: service_completed_successfully
       jwt-gen:
         condition: service_completed_successfully
-    profiles: ["node"]
+    profiles: ["node", "validator"]
 
   # Main node services
   geth:


### PR DESCRIPTION
This PR changes the profiles of `check-config` services so that on profile `node`, `check-config-validator` is not run and dummy validator secrets are not required. 