### PR TITLE
chore: Fixed profile dependency for validator-keygen service

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Once your node is fully synced, follow these steps to set up and run a validator
    If you need new keys:
    ```bash
    # Generate new keys
-   docker compose --profile manual run --rm validator-keygen
+   docker compose run --rm validator-keygen
 
    # Import generated keys
    docker compose --profile manual run --rm validator-import

--- a/container-scripts/validator-keygen.sh
+++ b/container-scripts/validator-keygen.sh
@@ -2,6 +2,21 @@
 
 set -e
 
+# Check NETWORK
+if [ "$NETWORK" != "moksha" ] && [ "$NETWORK" != "maya" ] && [ "$NETWORK" != "mainnet" ]; then
+  echo "Error: Invalid NETWORK '$NETWORK', must be either 'moksha' or 'maya' or 'mainnet'"
+  exit 1
+fi
+
+echo "NETWORK check passed: $NETWORK"
+
+# Check if WITHDRAWAL_ADDRESS is set and not the default value
+if [ -z "$WITHDRAWAL_ADDRESS" ] || [ "$WITHDRAWAL_ADDRESS" = "0x0000000000000000000000000000000000000000" ]; then
+    echo "Error: WITHDRAWAL_ADDRESS is not set or is still the default value."
+    echo "Please set a valid withdrawal address in your .env file."
+    exit 1
+fi
+
 python3 -m staking_deposit.deposit --language=${LANGUAGE:-English} new-mnemonic \
   --mnemonic_language=${LANGUAGE:-English} \
   --num_validators=${NUM_VALIDATORS:-1} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         condition: service_completed_successfully
       prysm-keygen:
         condition: service_completed_successfully
-    profiles: ["validator"]
+    profiles: ["validator", "manual"]
     secrets:
       - account_password
       - deposit_private_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         condition: service_completed_successfully
       prysm-keygen:
         condition: service_completed_successfully
-    profiles: ["validator", "manual"]
+    profiles: ["validator"]
     secrets:
       - account_password
       - deposit_private_key


### PR DESCRIPTION
The PR fixed the issue when running `validator-keygen` under the profile `manual`

```
~/vana-private$ sudo docker compose --profile manual run --rm validator-keygen
WARN[0000] The "BACKUP_FILE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "WS_SECRET" variable is not set. Defaulting to a blank string. 
service "check-config-validator" depends on undefined service "geth-init": invalid compose project
```